### PR TITLE
Include group information when completing password entries

### DIFF
--- a/bin/keepass-dmenu-cli.js
+++ b/bin/keepass-dmenu-cli.js
@@ -15,14 +15,14 @@ async.waterfall([
     // Present choice for entries
     function (entries, callback) {
         require('../lib/dmenuFilter')(entries.map(function (entry) {
-            return entry.title;
+            return entry.path;
         }), function (err, choice) {
             if (err) {
                 return callback(err);
             }
 
             var result = entries.filter(function (entry) {
-                return entry.title === choice;
+                return entry.path === choice;
             });
 
             if (result.length === 1) {

--- a/bin/keepass-dmenu-cli.js
+++ b/bin/keepass-dmenu-cli.js
@@ -8,6 +8,15 @@ var config = require('../lib/config')(argv);
 
 var defaultLabels = ['password', 'username', 'url', 'notes'];
 
+function formatEntry(entry) {
+    if (entry.meta.unique) {
+        return entry.title;
+    }
+
+    var path = entry.meta.path;
+    return entry.title + (path ? ' (' + path + ')' : '');
+}
+
 async.waterfall([
     require('../lib/getPassword')(config),
     require('../lib/createPassword')(config),
@@ -15,14 +24,14 @@ async.waterfall([
     // Present choice for entries
     function (entries, callback) {
         require('../lib/dmenuFilter')(entries.map(function (entry) {
-            return entry.toString();
+            return formatEntry(entry);
         }), function (err, choice) {
             if (err) {
                 return callback(err);
             }
 
             var result = entries.filter(function (entry) {
-                return entry.toString() === choice;
+                return formatEntry(entry) === choice;
             });
 
             if (result.length === 1) {
@@ -46,7 +55,7 @@ async.waterfall([
             var labels = defaultLabels.filter(function (label) {
                 return label in matched;
             }).concat(Object.keys(matched).filter(function (label) {
-                return defaultLabels.indexOf(label) === -1;
+                return label !== 'meta' && defaultLabels.indexOf(label) === -1;
             }).sort());
 
             require('../lib/dmenuFilter')(labels, function (err, choice) {

--- a/bin/keepass-dmenu-cli.js
+++ b/bin/keepass-dmenu-cli.js
@@ -15,14 +15,14 @@ async.waterfall([
     // Present choice for entries
     function (entries, callback) {
         require('../lib/dmenuFilter')(entries.map(function (entry) {
-            return entry.path;
+            return entry.toString();
         }), function (err, choice) {
             if (err) {
                 return callback(err);
             }
 
             var result = entries.filter(function (entry) {
-                return entry.path === choice;
+                return entry.toString() === choice;
             });
 
             if (result.length === 1) {

--- a/lib/flagUniqueEntries.js
+++ b/lib/flagUniqueEntries.js
@@ -1,0 +1,11 @@
+module.exports = function flagUniqueEntries(entries) {
+    var titles = entries.reduce(function (result, entry) {
+        result[entry.title] = result[entry.title] || 0;
+        result[entry.title] += 1;
+        return result;
+    }, {});
+
+    entries.forEach(function (entry) {
+        entry.meta.unique = titles[entry.title] === 1;
+    });
+};

--- a/lib/flattenedList.js
+++ b/lib/flattenedList.js
@@ -5,9 +5,8 @@ module.exports = function flattenedList(database, path) {
 
     if (database.entries) {
         database.entries.forEach(function (entry) {
-            entry.path = path;
-            entry.toString = function () {
-                return this.title + (entry.path ? ' (' + entry.path + ')' : '');
+            entry.meta = {
+                path: path
             };
             entries.push(entry);
         });

--- a/lib/flattenedList.js
+++ b/lib/flattenedList.js
@@ -1,19 +1,21 @@
 
 
 module.exports = function flattenedList(database, path) {
-    path = path ? path + '/' : '';
     var entries = [];
 
     if (database.entries) {
         database.entries.forEach(function (entry) {
-            entry.path = path + entry.title;
+            entry.path = path;
+            entry.toString = function () {
+                return this.title + (entry.path ? ' (' + entry.path + ')' : '');
+            };
             entries.push(entry);
         });
     }
 
     if (database.groups) {
         database.groups.map(function (group) {
-            return flattenedList(group, path + group.name);
+            return flattenedList(group, (path ? path + '/' + group.name : group.name));
         }).forEach(function (group) {
             entries = entries.concat(group);
         });

--- a/lib/flattenedList.js
+++ b/lib/flattenedList.js
@@ -1,16 +1,20 @@
 
 
-module.exports = function flattenedList(database) {
+module.exports = function flattenedList(database, path) {
+    path = path ? path + '/' : '';
     var entries = [];
 
     if (database.entries) {
         database.entries.forEach(function (entry) {
+            entry.path = path + entry.title;
             entries.push(entry);
         });
     }
 
     if (database.groups) {
-        database.groups.map(flattenedList).forEach(function (group) {
+        database.groups.map(function (group) {
+            return flattenedList(group, path + group.name);
+        }).forEach(function (group) {
             entries = entries.concat(group);
         });
     }

--- a/lib/loadDatabase.js
+++ b/lib/loadDatabase.js
@@ -14,6 +14,7 @@ module.exports = function (config) {
 
             data = require('./parseRawDatabase')(data);
             data = require('./flattenedList')(data);
+            require('./flagUniqueEntries')(data);
 
             callback(null, data);
         }));


### PR DESCRIPTION
This change make the name shown by dmenu contain the full path
to the entry. For example if you have a password for Facebook in
the Internet group, you will be presented with Internet/Facebook instead
of just Facebook.