### PR TITLE
Dejavu issue #2

### DIFF
--- a/lib/getPassword.js
+++ b/lib/getPassword.js
@@ -30,8 +30,8 @@ module.exports = function (config) {
                     fs.readFile.bind(fs, config.passwordCacheFile),
                     function (data, callback) {
                         data = JSON.parse(data);
-                        password = new kpio.Credentials.Password('temp');
-                        password.__hashBuffer = new Buffer(data.buffer);
+                        password = new kpio.Credentials.Password('temp'); 
+                        password.__hashBuffer = new Buffer(data.buffer); # This line fails with latest dejavu
                         callback();
                     },
                     // start a new reaper


### PR DESCRIPTION
Thought a PR would allow for easier discussion.

__hashBuffer is a private attribute and this was failing for me. I fixed it locally by adding a method in keepass.io to set the buffer, but it felt like a hack and not the correct way to do it. Once I get more personal time I might be able to figure out a correct way to do this, but that might be a while so I figured I would create this issue in the meanwhile in case someone else wants to take a crack at it.